### PR TITLE
add service range api route

### DIFF
--- a/controllers/api/serviceRangeRoutes.js
+++ b/controllers/api/serviceRangeRoutes.js
@@ -1,0 +1,55 @@
+const router = require('express').Router();
+const { ServiceRange } = require('../../models');
+
+router.get('/:providerId', async (req, res) => {
+    try {
+        const serviceRangeData = await ServiceRange.findOne(
+            { 
+                where: { service_provider_id: req.params.providerId }
+            }
+        );
+
+        if (!serviceRangeData) {
+            res.status(404).json({ message: "No service range data found"} );
+            return;
+        }
+        
+        res.status(200).json(serviceRangeData.get({ plain: true }));
+
+    } catch (err) {
+        res.status(500).json(err);
+    }
+});
+
+router.post('/:providerId', async (req, res) => {
+    try {
+        const serviceRangeData = await ServiceRange.create(
+            { 
+                service_provider_id: providerId,
+                range_miles: req.body.range_miles
+            }
+        );
+        res.status(200).json(serviceRangeData);
+    } catch (err) {
+        res.status(500).json(err);
+    }
+});
+
+router.put('/:providerId', async (req, res) => {
+    try {
+        const serviceRangeData = await ServiceRange.update(
+            {
+                range_miles: req.body.range_miles
+            },
+            {
+                where: {
+                    service_provider_id: providerId
+                }
+            }   
+        );
+        res.status(200).json(serviceRangeData);
+    } catch (err) {
+        res.status(500).json(err);
+    }
+});
+

--- a/models/serviceRange.js
+++ b/models/serviceRange.js
@@ -12,6 +12,7 @@ ServiceRange.init(
     },
     service_provider_id: {
       type: DataTypes.INTEGER,
+      unique: true,
       allowNull: false
     },
     range_miles: {


### PR DESCRIPTION
Added service range API route and updated serviceRange model to enforce unique `service_provider_id`s.  This is needed to ensure only one range value is available per service provider.